### PR TITLE
removed notification_source_arns variable from resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "sqs-allow-send_messages" {
     ]
 
     resources = [
-      "${var.notification_source_arns}",
+      "${aws_sqs_queue.this.0.arn}",
     ]
 
     principals = {


### PR DESCRIPTION
Pull request will fix sqs permissions policy and allow send sns notifications to sqs queue